### PR TITLE
Give greater control over link order and naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ container configuration.
 | `DASHBOARD_BACKGROUND_COLOR` | `"#f29a00"`                   | `"#000000"`                                  |
 | `DASHBOARD_LINK_<name>`      | None, add as many as you want | `DASHBOARD_LINK_GOOGLE="https://google.com"` |
 
+If you want more control over the order and naming of items, you can do something like this:
+
+| Environment variable | Value                                |
+| -------------------- | ------------------------------------ |
+| `DASHBOARD_LINK_00`  | `/website-nl\|Website NL at the top` |
+| `DASHBOARD_LINK_01`  | `/website-nl\|Website EN after that` |
+| `DASHBOARD_LINK_02`  | `/cms\|CMS at the bottom`            |
+
+This way the order is based on the key but for the name anything after `|` in the value is used.
+
 ## Preview
 
 | Default config                     | Custom config                       |

--- a/dashboard.css
+++ b/dashboard.css
@@ -41,7 +41,6 @@ h1 {
 
 a {
 	display: block;
-	text-transform: lowercase;
 	background: #00000010;
 	padding: 1rem;
 	color: var(text-color);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
             - '.:/opt/enrise/dashboard'
         command: deno run -A --watch main.ts
         environment:
-            DASHBOARD_LINK_WEBSITE_NL: '/website-nl'
-            DASHBOARD_LINK_WEBSITE_EN: '/website-en'
-            DASHBOARD_LINK_CMS: '/cms'
+            DASHBOARD_LINK_WEBSITE_NL: '/website-nl|Website NL'
+            DASHBOARD_LINK_WEBSITE_EN: '/website-en|Website EN'
+            DASHBOARD_LINK_CMS: '/cms|CMS'
             DASHBOARD_LINK_MAIL: '/mailhog'

--- a/main.ts
+++ b/main.ts
@@ -11,8 +11,14 @@ const buildLinkList = (): string => {
 		.sort()
 		.forEach(function (name) {
 			if (name.startsWith(`${dashboardPrefix}LINK`)) {
-				const cleanName = name.replace(`${dashboardPrefix}LINK_`, '').replaceAll('_', ' ');
-				listItems.push(`<a href="${envs[name]}">${cleanName}</a>`);
+				let link = envs[name];
+				let cleanName = name.replace(`${dashboardPrefix}LINK_`, '').replaceAll('_', ' ').toLowerCase();
+				if (envs[name].includes('|')) {
+					const parts  = envs[name].split('|');
+					link = parts[0];
+					cleanName = parts[1];
+				}
+				listItems.push(`<a href="${link}">${cleanName}</a>`);
 			}
 		});
 


### PR DESCRIPTION
## What

This PR allows for optional control over the order in which the links are shown, and what text is shown per link. If omitted, the default order and naming will be used, like it already was working before this change.

## How to test

1. Pull this branch and run the project locally
2. See the changes in the `README.md`
3. See the changes in `docker-compose.yml` and how it effects the dashboard
4. See nicer cleaner names in the dashboard links
5. See that the links still point to the correct URLs
