### PR TITLE
Add another row of links if more than 8 links are specified

### DIFF
--- a/resources/dashboard.css
+++ b/resources/dashboard.css
@@ -59,7 +59,13 @@ a:first-letter {
 	text-transform: uppercase !important;
 }
 
-@media (min-width: 500px) {
+@media (min-width: 22rem) {
+	img {
+		width: 18.2rem;
+	}
+}
+
+@media (min-width: 36rem) {
 	h1 {
 		font-size: 1.8rem;
 	}
@@ -69,8 +75,20 @@ a:first-letter {
 	}
 }
 
-@media (min-width: 400px) {
-	img {
-		width: 70%;
+@media (min-width: 60rem) {
+	.container {
+		width: 57rem;
+		max-width: unset;
+	}
+
+	.link-list {
+		align-items: center;
+		max-width: 53rem;
+		max-height: 40rem;
+		flex-wrap: wrap;
+	}
+
+	a {
+		width: 26rem;
 	}
 }

--- a/resources/dashboard.css
+++ b/resources/dashboard.css
@@ -83,8 +83,10 @@ a:first-letter {
 
 	.link-list {
 		align-items: center;
-		max-width: 53rem;
-		max-height: 40rem;
+	}
+
+	.link-list:has(> :nth-child(9)) {
+		flex-direction: row;
 		flex-wrap: wrap;
 	}
 


### PR DESCRIPTION
## What

On dashboards that have 10+ links, the list becomes longer than the height of the monitor, however there is a lot of wasted space horizontally.

This MR updates the layout so that up to 16 links can be displayed comfortable on a wider screen, whilst keeping the original scroll behaviour on a mobile devices.

The layout stays exactly the same as before, unless you are on a desktop monitor with more than 60rem of screen space horizontally. In that case an extra row of links will be shown.

## Also

To make flexbox behave as I intended, I had to add a specific min-width based on rem, because a few other dimensions were also based on rem. To prevent having a mix of rem and pixels, I updated the other breakpoints as well. The CSS file is now logical and easy to read.

## How to test

1. Pull this branch and see that the dashboard looks exactly the same pixel for pixel.
2. Add a bunch of extra links to docker-compose.yml, restart, and see that on desktop an extra row appears with the correct gaps both horizontally and vertically.
3. See that no mobile functionality was impacted by this change, e.g. the list of links is still a single long list that can be scrolled.
4. Using the mobile tools in any browser, see that the breakpoints are smooth and the logo always has the correct width.
