### PR TITLE
Update Deno base image to version 2.5.0 instead of latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:latest
+FROM denoland/deno:2.5.0
 
 USER deno
 


### PR DESCRIPTION
Use specific version numbers instead of latest, this ensures the repo will get auto updated by renovate whenever a new version is available. This will help with pushing essential package updates and patches when they're available.